### PR TITLE
fixed the error in conda env making

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Swift for TensorFlow requires CUDNN 7.5, but Conda only has CUDNN 7.3).
 Create a Conda environment and install some packages in it:
 
 ```bash
-conda create -n swift-tensorflow python==3.6
+conda create -n swift-tensorflow python=3.6
 conda activate swift-tensorflow
 conda install jupyter numpy matplotlib
 ```


### PR DESCRIPTION
the correct command line is 
`conda create -n swift-tensorflow python=3.6`
, not python==3.6